### PR TITLE
feat: Enable GPU memory UAPIs (VRAM & GTT)

### DIFF
--- a/lite_gpu.c
+++ b/lite_gpu.c
@@ -24,6 +24,7 @@ MODULE_VERSION("0.1");
 #define LITE_GPU_VENDOR_ID 0x1ED5  // Example Vendor ID
 #define LITE_GPU_DEVICE_ID 0x1000  // Example Device ID
 #define LITE_VRAM_SIZE (256 * 1024 * 1024) // 256MB
+#define LITE_GTT_SIZE (1024 * 1024 * 1024) // 1GB
 
 static const struct pci_device_id lite_gpu_ids[] = {
     { PCI_DEVICE(LITE_GPU_VENDOR_ID, LITE_GPU_DEVICE_ID) },
@@ -92,6 +93,12 @@ static int lite_ttm_init(struct lite_device *ldev)
     /* Initialize VRAM manager */
     ret = ttm_range_manager_init(&ldev->ttm, TTM_PL_VRAM, false,
                                  LITE_VRAM_SIZE >> PAGE_SHIFT);
+    if (ret)
+        return ret;
+
+    /* Initialize GTT manager */
+    ret = ttm_range_manager_init(&ldev->ttm, TTM_PL_TT, false,
+                                 LITE_GTT_SIZE >> PAGE_SHIFT);
     if (ret)
         return ret;
 

--- a/lite_gpu.c
+++ b/lite_gpu.c
@@ -130,11 +130,12 @@ static inline struct lite_device *to_lite_device(struct drm_device *dev)
 
 static void lite_bo_placement(struct ttm_placement *placement,
                               struct ttm_place *places,
-                              uint32_t domain)
+                              uint32_t flags)
 {
     int i = 0;
 
-    if (domain & TTM_PL_FLAG_VRAM) {
+    /* If user requested VRAM, try VRAM first */
+    if (flags & LITE_GEM_DOMAIN_VRAM) {
         places[i].fpfn = 0;
         places[i].lpfn = 0;
         places[i].mem_type = TTM_PL_VRAM;
@@ -142,12 +143,30 @@ static void lite_bo_placement(struct ttm_placement *placement,
         i++;
     }
     
-    // System fallback
-    places[i].fpfn = 0;
-    places[i].lpfn = 0;
-    places[i].mem_type = TTM_PL_SYSTEM;
-    places[i].flags = 0;
-    i++;
+    /* If user requested GTT, or if VRAM request failed/not requested and we need fallback */
+    if (flags & LITE_GEM_DOMAIN_GTT) {
+        places[i].fpfn = 0;
+        places[i].lpfn = 0;
+        places[i].mem_type = TTM_PL_TT;
+        places[i].flags = 0;
+        i++;
+    }
+
+    /* Fallback to System/GTT if nothing valid specified or strict flags not used */
+    if (i == 0) {
+        // Default to VRAM then GTT
+         places[i].fpfn = 0;
+         places[i].lpfn = 0;
+         places[i].mem_type = TTM_PL_VRAM;
+         places[i].flags = 0;
+         i++;
+         
+         places[i].fpfn = 0;
+         places[i].lpfn = 0;
+         places[i].mem_type = TTM_PL_TT;
+         places[i].flags = 0;
+         i++;
+    }
     
     placement->num_placement = i;
     placement->placement = places;
@@ -155,12 +174,12 @@ static void lite_bo_placement(struct ttm_placement *placement,
     placement->busy_placement = places;
 }
 
-static int lite_bo_create(struct lite_device *ldev, size_t size,
+static int lite_bo_create(struct lite_device *ldev, size_t size, uint32_t flags,
                           struct lite_gem_object **pobj)
 {
     struct lite_gem_object *obj;
     struct ttm_placement placement = {};
-    struct ttm_place places[2]; // VRAM + SYSTEM
+    struct ttm_place places[4]; 
     int ret;
 
     obj = kzalloc(sizeof(*obj), GFP_KERNEL);
@@ -171,12 +190,12 @@ static int lite_bo_create(struct lite_device *ldev, size_t size,
     obj->base.funcs = &lite_gem_funcs;
     drm_gem_private_object_init(&ldev->drm, &obj->base, size);
     
-    /* Setup placement (Prefer VRAM) */
-    lite_bo_placement(&placement, places, TTM_PL_FLAG_VRAM);
+    /* Setup placement based on flags */
+    lite_bo_placement(&placement, places, flags);
 
     /* Initialize TTM BO */
     obj->bo.destroy = lite_bo_destroy;
-    ret = ttm_bo_init_validate(&ldev->ttm, &obj->bo, TTM_PL_FLAG_VRAM,
+    ret = ttm_bo_init_validate(&ldev->ttm, &obj->bo, TTM_PL_FLAG_VRAM | TTM_PL_FLAG_TT,
                                &placement, PAGE_ALIGN(size) >> PAGE_SHIFT,
                                false, NULL, NULL, NULL);
     if (ret) {
@@ -207,7 +226,7 @@ static int lite_ioctl_gem_create(struct drm_device *dev, void *data, struct drm_
 
     args->size = PAGE_ALIGN(args->size);
 
-    ret = lite_bo_create(ldev, args->size, &obj);
+    ret = lite_bo_create(ldev, args->size, args->flags, &obj);
     if (ret)
         return ret;
 

--- a/lite_uapi.h
+++ b/lite_uapi.h
@@ -13,6 +13,10 @@
 #define DRM_LITE_SUBMIT_CMD     0x03
 #define DRM_LITE_WAIT_BO        0x04
 
+/* Memory Domain Flags */
+#define LITE_GEM_DOMAIN_VRAM    0x1
+#define LITE_GEM_DOMAIN_GTT     0x2
+
 /* Data structures */
 
 /**

--- a/test_gpu.c
+++ b/test_gpu.c
@@ -24,15 +24,16 @@ int main() {
     }
     printf("Opened GPU device\n");
 
-    /* 1. Allocate Memory */
+    /* 1. Allocate Memory (VRAM) */
+    printf("Allocating VRAM buffer...\n");
     create_args.size = 4096;
-    create_args.flags = 0;
+    create_args.flags = LITE_GEM_DOMAIN_VRAM;
     if (ioctl(fd, DRM_IOCTL_LITE_GEM_CREATE, &create_args)) {
-        perror("GEM Create failed");
+        perror("GEM Create VRAM failed");
         close(fd);
         return 1;
     }
-    printf("Created GEM Object. Handle: %u, Size: %llu\n", create_args.handle, create_args.size);
+    printf("Created VRAM Object. Handle: %u, Size: %llu\n", create_args.handle, create_args.size);
 
     /* 2. Map Memory */
     map_args.handle = create_args.handle;
@@ -54,9 +55,45 @@ int main() {
 
     /* Write validation */
     *(int*)ptr = 0xDEADBEEF;
-    printf("Wrote to memory: 0x%x\n", *(int*)ptr);
-
+    printf("Wrote to VRAM: 0x%x\n", *(int*)ptr);
     munmap(ptr, create_args.size);
+
+    /* 4. Allocate Memory (GTT) */
+    printf("\nAllocating GTT buffer...\n");
+    memset(&create_args, 0, sizeof(create_args));
+    create_args.size = 8192;
+    create_args.flags = LITE_GEM_DOMAIN_GTT;
+    if (ioctl(fd, DRM_IOCTL_LITE_GEM_CREATE, &create_args)) {
+        perror("GEM Create GTT failed");
+        close(fd);
+        return 1;
+    }
+    printf("Created GTT Object. Handle: %u, Size: %llu\n", create_args.handle, create_args.size);
+
+    /* 5. Map Memory (GTT) */
+    memset(&map_args, 0, sizeof(map_args));
+    map_args.handle = create_args.handle;
+    if (ioctl(fd, DRM_IOCTL_LITE_GEM_MAP, &map_args)) {
+        perror("GEM Map GTT failed");
+        close(fd);
+        return 1;
+    }
+    printf("GEM Mapped GTT. Offset: 0x%llx\n", map_args.offset);
+
+    /* 6. MMAP (GTT) */
+    ptr = mmap(NULL, create_args.size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, map_args.offset);
+    if (ptr == MAP_FAILED) {
+        perror("mmap GTT failed");
+        close(fd);
+        return 1;
+    }
+    printf("mmap GTT successful. Ptr: %p\n", ptr);
+
+    /* Write validation (GTT) */
+    *(int*)ptr = 0xCAFEBABE;
+    printf("Wrote to GTT: 0x%x\n", *(int*)ptr);
+    munmap(ptr, create_args.size);
+
     close(fd);
     return 0;
 }


### PR DESCRIPTION
Implements support for VRAM and GTT memory domains via UAPI flags.

Resolves #6

Changes:
- Defined LITE_GEM_DOMAIN_VRAM and LITE_GEM_DOMAIN_GTT flags
- Initialized GTT memory manager
- Updated BO placement logic to respect user flags
- Updated test_gpu.c to verify both domains